### PR TITLE
Fix activities not being submitted on localhost resolution failure

### DIFF
--- a/src/com/codealike/client/core/internal/tracking/ActivitiesRecorder.java
+++ b/src/com/codealike/client/core/internal/tracking/ActivitiesRecorder.java
@@ -174,7 +174,8 @@ public class ActivitiesRecorder {
 		//	return FlushResult.Skip;
 		//}
 		
-		List<ActivityInfo> activityInfoList = processor.getSerializableEntities(InetAddress.getLocalHost().getHostName(), 
+		String machineName = findLocalHostNameOr("unknown");
+		List<ActivityInfo> activityInfoList = processor.getSerializableEntities(machineName, 
 				context.getInstanceValue(), "intellij", context.getPluginVersion());
 		String activityLogExtension = context.getProperty("activity-log.extension");
 		if (!processor.isActivityValid(activityInfoList)) {
@@ -252,6 +253,14 @@ public class ActivitiesRecorder {
 			}
 		}
 		return result;
+	}
+	
+	private String findLocalHostNameOr(String defaultName) {
+		try {
+			return InetAddress.getLocalHost().getHostName();
+		} catch (UnknownHostException e) { //see: http://stackoverflow.com/a/40702767/1117552
+			return defaultName;
+		}
 	}
 
 	private void trySendEntriesOnFile(File fileEntry, String username, String token) {


### PR DESCRIPTION
Hello!

I'm quite excited for the new Codealike IntelliJ plugin and especially appreciate that you publish the source code. I found a small issue that occurred on my machine an figured I might as well submit a PR.

## The issue
On some hosts with specific networking configurations, `InetAddress.getLocalHost().getHostName()` fails with an `UnknownHostException`. This causes the Codealike IntelliJ plugin to fail while trying to push activities to the server. A usual stack trace might look like this:

````
CodealikeApplicationComponent: Couldn't send data to the server.: lightbulb: lightbulb: Name or service not known
java.net.UnknownHostException: lightbulb: lightbulb: Name or service not known
	at java.net.InetAddress.getLocalHost(InetAddress.java:1505)
	at com.codealike.client.core.internal.tracking.ActivitiesRecorder.flush(ActivitiesRecorder.java:177)
	at com.codealike.client.core.internal.tracking.StateTracker.flush(StateTracker.java:251)
	at com.codealike.client.core.internal.services.TrackingService$1.run(TrackingService.java:98)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.net.UnknownHostException: lightbulb: Name or service not known
	at java.net.Inet4AddressImpl.lookupAllHostAddr(Native Method)
	at java.net.InetAddress$2.lookupAllHostAddr(InetAddress.java:928)
	at java.net.InetAddress.getAddressesFromNameService(InetAddress.java:1323)
	at java.net.InetAddress.getLocalHost(InetAddress.java:1500)
	... 10 more
````

The issue results from unusual (broken?) networking configuration where the local host name does not directly resolve to an ip address. [This StackOverflow answer details the issues with calling `InetAddress.getLocalHost().getHostName()` without verification](http://stackoverflow.com/a/40702767/1117552). 

## Justification

In my case, the issue was caused by the host name not being in `/etc/hosts`, but according to that answer, this issue may also appear under different circumstances. Since my solution does - in my opinion - not really bloat the code and should not have any performance penalties, and there may be valid cases where such an exception might occur, I believe that it is reasonable to include this change into the project.

## Implementation notes

This PR changes the behaviour of `ActivitiesRecorder` such that it does not fail completely under the described circumstances. Previously, activities would never be pushed if such an error occurred. With these changes, if the hostname lookup fails, the plugin sends the activity data to the server, with a hostname of `unknown`.

## Tests

Full disclosure: I have not tested this, but the code should be trivial enough such that it has a very small risk of failing on execution.

Thanks!