### PR TITLE
Trackign improvements

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin version="2">
   <id>com.codealike.client.intellij.plugin</id>
   <name>Codealike</name>
-  <version>1.5.0.5</version>
+  <version>1.5.0.8</version>
   <vendor email="support@codealike.com" url="https://codealike.com">Codealike</vendor>
 
   <description><![CDATA[

--- a/src/com/codealike/client/core/internal/services/TrackingService.java
+++ b/src/com/codealike/client/core/internal/services/TrackingService.java
@@ -187,6 +187,9 @@ public class TrackingService extends Observable {
 	public void disableTracking() {
 		stopTracking(true);
 
+		// flush last information before leaving
+		flushTrackingInformation();
+
 		Notification note = new Notification("CodealikeApplicationComponent.Notifications",
 				"Codealike",
 				"Codealike  is not tracking your projects",

--- a/src/com/codealike/client/core/internal/startup/PluginContext.java
+++ b/src/com/codealike/client/core/internal/startup/PluginContext.java
@@ -40,7 +40,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 
 @SuppressWarnings("restriction")
 public class PluginContext {
-	public static final String VERSION = "0.0.1";
+	public static final String VERSION = "1.5.0.8";
 	private static final String PLUGIN_PREFERENCES_QUALIFIER = "com.codealike.client.intellij";
 	private static PluginContext _instance;
 

--- a/src/com/codealike/client/intellij/CodealikeProjectComponent.java
+++ b/src/com/codealike/client/intellij/CodealikeProjectComponent.java
@@ -2,6 +2,7 @@ package com.codealike.client.intellij;
 
 import com.codealike.client.core.internal.services.IdentityService;
 import com.codealike.client.core.internal.services.TrackingService;
+import com.codealike.client.core.internal.startup.PluginContext;
 import com.intellij.debugger.DebuggerManager;
 import com.intellij.debugger.engine.DebugProcessEvents;
 import com.intellij.notification.Notification;
@@ -43,8 +44,30 @@ public class CodealikeProjectComponent implements ProjectComponent {
     @Override
     public void projectOpened() {
         // called when project is opened
-        if (TrackingService.getInstance().isTracking()) {
-            TrackingService.getInstance().startTracking(_project);
+        PluginContext pluginContext = PluginContext.getInstance();
+        TrackingService trackingService = pluginContext.getTrackingService();
+        IdentityService identityService = pluginContext.getIdentityService();
+        if (identityService.isAuthenticated()) {
+            switch(identityService.getTrackActivity()) {
+                case Always:
+                {
+                    pluginContext.getTrackingService().setBeforeOpenProjectDate();
+                    trackingService.enableTracking();
+                    trackingService.startTracking(_project);
+                    break;
+                }
+                case AskEveryTime:
+                case Never:
+                    Notification note = new Notification("CodealikeApplicationComponent.Notifications",
+                            "Codealike",
+                            "Codealike  is not tracking your projects",
+                            NotificationType.INFORMATION);
+                    Notifications.Bus.notify(note);
+                    break;
+            }
+        }
+        else {
+            trackingService.disableTracking();
         }
     }
 
@@ -53,6 +76,7 @@ public class CodealikeProjectComponent implements ProjectComponent {
         // called when project is being closed
         if (TrackingService.getInstance().isTracking()) {
             TrackingService.getInstance().stopTracking(_project);
+            TrackingService.getInstance().disableTracking();
         }
     }
 }

--- a/src/com/codealike/client/intellij/codealike.properties
+++ b/src/com/codealike/client/intellij/codealike.properties
@@ -2,6 +2,6 @@ codealike.server.url = https://codealike.com
 activity-log.path = Codealike.Intellij.TrackerCacheDev
 activity-log.extension = .data
 activity-log.trace-sent = true
-activity-log.interval.secs = 30
+activity-log.interval.secs = 180
 tracking-console.enabled = true
 activity-verbose-notifications = false


### PR DESCRIPTION
- Flush information on project close
- Reload projects when authenticated status change
- Tracking starts when project is opened
- Tracking flush period moved to 3 minutes