### PR TITLE
Removing Internal API usages and replacing deprecated API usages

### DIFF
--- a/src/main/java/com/codealike/client/core/internal/tracking/StateTracker.java
+++ b/src/main/java/com/codealike/client/core/internal/tracking/StateTracker.java
@@ -17,6 +17,7 @@ import com.codealike.client.core.internal.utils.TrackingConsole;
 import com.codealike.client.intellij.EventListeners.CustomCaretListener;
 import com.codealike.client.intellij.EventListeners.CustomDocumentListener;
 import com.codealike.client.intellij.EventListeners.CustomEditorMouseListener;
+import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.EditorFactory;
@@ -24,6 +25,7 @@ import com.intellij.openapi.editor.event.CaretListener;
 import com.intellij.openapi.editor.event.DocumentListener;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.*;
 import com.intellij.psi.util.PsiTreeUtil;
@@ -206,23 +208,24 @@ public class StateTracker {
         documentListener = new CustomDocumentListener();
         caretListener = new CustomCaretListener();
         editorMouseListener = new CustomEditorMouseListener();
+        Disposable disposable = Disposer.newDisposable();
 
         ApplicationManager.getApplication().invokeLater(() -> {
 
             EditorFactory
                     .getInstance()
                     .getEventMulticaster()
-                    .addDocumentListener(documentListener);
+                    .addDocumentListener(documentListener, disposable);
 
             EditorFactory
                     .getInstance()
                     .getEventMulticaster()
-                    .addCaretListener(caretListener);
+                    .addCaretListener(caretListener, disposable);
 
             EditorFactory
                     .getInstance()
                     .getEventMulticaster()
-                    .addEditorMouseListener(editorMouseListener);
+                    .addEditorMouseListener(editorMouseListener, disposable);
         });
 
         startIdleDetection();

--- a/src/main/java/com/codealike/client/intellij/ProjectConfig.java
+++ b/src/main/java/com/codealike/client/intellij/ProjectConfig.java
@@ -1,7 +1,6 @@
 package com.codealike.client.intellij;
 
 import com.intellij.openapi.components.PersistentStateComponent;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
 import com.intellij.openapi.project.Project;
@@ -27,7 +26,7 @@ public class ProjectConfig implements PersistentStateComponent<ProjectConfig.Con
 
     @Nullable
     public static ProjectConfig getInstance(Project project) {
-        return ServiceManager.getService(project, ProjectConfig.class);
+        return project.getService(ProjectConfig.class);
     }
 
     public UUID getProjectId() {


### PR DESCRIPTION
Removing internal API usages in `PluginContext.java` i.e. using `ApplicationNamesInfo` instead of `PlatformUtils`
Replacing deprecated API usages for 
- `PluginContext.java` -> Replacing `project.getBaseDir()` with `IProjectStore`
- `StateTracker.java` -> Replacing ` addDocumentListener(DocumentListener)` with ` addDocumentListener(DocumentListener, Disposable)`
- `ProjectConfig.java` -> Replacing `ServiceManager.getService(Project, Class)` with ` ComponentManager.getService(Class)` i.e. `project.getService(Class)`

**NOTE**

There remain 3 deprecated usages in the code base wrt to `ApplicationComponent` in `CodealikeApplicationComponent.java` file. Please review the attached image and [link](https://plugins.jetbrains.com/docs/intellij/plugin-components.html).


![image](https://github.com/Codealike/Codealike-Jetbrains/assets/86152429/46679c2f-3777-4fd3-81ad-49ebd733a846)

